### PR TITLE
Update navBar.astro: fix link

### DIFF
--- a/website/src/components/navBar.astro
+++ b/website/src/components/navBar.astro
@@ -32,8 +32,7 @@ import Logo from "./logo.astro";
             <a href="/llm" class="transition-all mr-4 hover:text-white/70">AI</a
             >
             <a
-                href="
-                integrations"
+                href="/integrations"
                 class="mr-4 hover:text-white/70 transition-all">Integrations</a
             >
             <a href="/docs" class="mr-4 hover:text-white/70 transition-all"


### PR DESCRIPTION
Fix link:

Steps to reproduce:
-	Go to [Outlook Calendar Integration](https://anyquery.dev/integrations/outlook-calendar).
-	Clicking `Integrations` in the navigation bar currently leads to:
-	https://anyquery.dev/integrations/integrations
-	It should instead lead to:
-	https://anyquery.dev/integrations

Note:
-	I haven’t tested the new link with generated website from astro files - I only fixed it in the GitHub web editor. Please verify if it’s the correct place to apply the fix.