### PR TITLE
Add Arch Linux installation instructions via AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ brew install anyquery
 sudo snap install anyquery
 ``` -->
 ### ARCH LINUX (AUR)
-```bash 
-#Install using an AUR helper like yay
+
+```bash
+# Install using an AUR helper like yay
 yay -S anyquery-git
 
-#paru
+# paru
 paru -S anyquery-git
 ```
 

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -58,6 +58,16 @@ sudo dnf install anyquery
 sudo snap install anyquery
 ``` -->
 
+### Arch Linux (AUR)
+
+```bash
+# Install using an AUR helper like yay
+yay -S anyquery-git
+
+# paru
+paru -S anyquery-git
+```
+
 ### MacOS (Homebrew)
 
 ```bash


### PR DESCRIPTION
#65 Add installation instructions for Arch Linux users through AUR (Arch User Repository).