### PR TITLE
fix(mysql): Escape column names with backticks to handle reserved keyword

### DIFF
--- a/module/clickhouse.go
+++ b/module/clickhouse.go
@@ -375,7 +375,7 @@ func (t *ClickHouseTable) Destroy() error {
 // To find the method, we will ask the database to explain the query and return the best method
 func (t *ClickHouseTable) BestIndex(cst []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy, info sqlite3.IndexInformation) (*sqlite3.IndexResult, error) {
 	// Create the SQL query
-	queryBuilder, limitCstIndex, offsetCstIndex, used := efficientConstructSQLQuery(cst, ob, t.schema, t.tableName, info.ColUsed)
+	queryBuilder, limitCstIndex, offsetCstIndex, used := efficientConstructSQLQuery(cst, ob, t.schema, t.tableName, info.ColUsed, sqlbuilder.ClickHouse)
 	queryBuilder.SetFlavor(sqlbuilder.ClickHouse)
 	rawQuery, args := queryBuilder.Build()
 	rawQuery += sqlQuerySuffix

--- a/module/duckdb.go
+++ b/module/duckdb.go
@@ -275,7 +275,7 @@ func (t *DuckDBTable) Destroy() error {
 // To find the method, we will ask the database to explain the query and return the best method
 func (t *DuckDBTable) BestIndex(cst []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy, info sqlite3.IndexInformation) (*sqlite3.IndexResult, error) {
 	// Create the SQL query
-	queryBuilder, limitCstIndex, offsetCstIndex, used := efficientConstructSQLQuery(cst, ob, t.schema, t.tableName, info.ColUsed)
+	queryBuilder, limitCstIndex, offsetCstIndex, used := efficientConstructSQLQuery(cst, ob, t.schema, t.tableName, info.ColUsed, sqlbuilder.PostgreSQL)
 	queryBuilder.SetFlavor(sqlbuilder.PostgreSQL)
 	rawQuery, args := queryBuilder.Build()
 

--- a/module/mysql.go
+++ b/module/mysql.go
@@ -476,7 +476,7 @@ func (t *MySQLTable) Destroy() error {
 // To find the method, we will ask the database to explain the query and return the best method
 func (t *MySQLTable) BestIndex(cst []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy, info sqlite3.IndexInformation) (*sqlite3.IndexResult, error) {
 	// Create the SQL query
-	queryBuilder, limitCstIndex, offsetCstIndex, used := constructSQLQuery(cst, ob, t.schema, t.tableName)
+	queryBuilder, limitCstIndex, offsetCstIndex, used := constructSQLQuery(cst, ob, t.schema, t.tableName, sqlbuilder.MySQL)
 	queryBuilder.SetFlavor(sqlbuilder.MySQL)
 	rawQuery, args := queryBuilder.Build()
 	rawQuery += sqlQuerySuffix

--- a/module/postgres.go
+++ b/module/postgres.go
@@ -336,7 +336,7 @@ func (t *PostgresTable) Destroy() error {
 // To find the method, we will ask the database to explain the query and return the best method
 func (t *PostgresTable) BestIndex(cst []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy, info sqlite3.IndexInformation) (*sqlite3.IndexResult, error) {
 	// Create the SQL query
-	queryBuilder, limitCstIndex, offsetCstIndex, used := constructSQLQuery(cst, ob, t.schema, t.tableName)
+	queryBuilder, limitCstIndex, offsetCstIndex, used := constructSQLQuery(cst, ob, t.schema, t.tableName, sqlbuilder.PostgreSQL)
 	queryBuilder.SetFlavor(sqlbuilder.PostgreSQL)
 	rawQuery, args := queryBuilder.Build()
 	rawQuery += sqlQuerySuffix


### PR DESCRIPTION
Fixes issue where MySQL tables with reserved keyword columns (e.g., `order`) cannot be queried due to missing backtick escaping in generated SQL.

Changes:
- Add flavor parameter to constructSQLQuery() and efficientConstructSQLQuery()
- Use flavor.Quote() to properly escape column names based on database type
- MySQL uses backticks (`column`), PostgreSQL uses double quotes ("column")
- Apply escaping to both SELECT columns and ORDER BY clauses

Impact:
- Fixes queries on any MySQL table with reserved keyword columns
- Similar to PR #57 which fixed PostgreSQL column name handling

Tested:
- Successfully queried table with 'order' column
- Verified COUNT, SELECT, and aggregation queries work correctly
- Tested with 284,909 relationship records

Example working query:
  SELECT id1, id2, name FROM connection.post_to_post LIMIT 5