### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/controller/llm.go
+++ b/controller/llm.go
@@ -671,7 +671,11 @@ func Mcp(cmd *cobra.Command, args []string) error {
 	s := server.NewMCPServer("Anyquery", "0.1.0")
 
 	// Create the MCP server
-	tool := mcp.NewTool("listTables", mcp.WithDescription("Lists all the tables available. When the user requests data, or wants an action (insert/update/delete), call this endpoint to check if a table corresponds to the user's request."))
+	tool := mcp.NewTool("listTables",
+		mcp.WithDescription("Lists all the tables available. When the user requests data, or wants an action (insert/update/delete), call this endpoint to check if a table corresponds to the user's request."),
+		mcp.WithTitleAnnotation("List Tables"),
+		mcp.WithReadOnlyHintAnnotation(true),
+	)
 
 	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		if authEnabled {
@@ -697,7 +701,10 @@ func Mcp(cmd *cobra.Command, args []string) error {
 
 	tool = mcp.NewTool("describeTable",
 		mcp.WithDescription("Describes a table. It returns the columns of the table, the supported operations, and the SQL examples. Before calling executeQuery, you must call this endpoint for each table you want to interact with."),
-		mcp.WithString("tableName", mcp.Required(), mcp.Description("The name of the table to describe")))
+		mcp.WithTitleAnnotation("Describe Table"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("tableName", mcp.Required(), mcp.Description("The name of the table to describe")),
+	)
 
 	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		if authEnabled {
@@ -788,7 +795,10 @@ To install Anyquery, the user must follow the tutorial at https://anyquery.dev/d
 
 By default, Anyquery does not have any integrations. The user must visit https://anyquery.dev/integrations to find some integrations they might like and follow the instructions to add them.
 `),
-		mcp.WithString("query", mcp.Required(), mcp.Description("The SQL query to execute")))
+		mcp.WithTitleAnnotation("Execute Query"),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("query", mcp.Required(), mcp.Description("The SQL query to execute")),
+	)
 	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		if authEnabled {
 			suppliedToken := request.Header.Get("Authorization")


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all three MCP tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to `listTables` (read-only table listing)
- Added `readOnlyHint: true` to `describeTable` (read-only schema lookup)
- Added `destructiveHint: true` to `executeQuery` (can execute INSERT/UPDATE/DELETE queries)
- Added `title` annotations for human-readable display

## Why This Matters

Tool annotations provide semantic metadata that MCP clients can use to:
- **Auto-approve safe operations**: Clients like Claude Code can automatically approve read-only tools without user confirmation
- **Prompt for confirmation**: Destructive tools trigger confirmation prompts before execution
- **Display meaningful titles**: Human-readable names improve UI/UX in client applications
- **Enable safer automation**: Workflows can distinguish between read and write operations

## Tool Summary

| Tool | Title | ReadOnly | Destructive |
|------|-------|----------|-------------|
| `listTables` | List Tables | ✅ | - |
| `describeTable` | Describe Table | ✅ | - |
| `executeQuery` | Execute Query | - | ✅ |

## Testing

- [x] Code follows mcp-go annotation patterns (WithTitleAnnotation, WithReadOnlyHintAnnotation, WithDestructiveHintAnnotation)
- [x] Using mcp-go v0.41.0 which fully supports annotations
- [x] Annotation values match actual tool behavior

**Note:** Live verification requires full Anyquery setup with database plugins. The annotation syntax follows the established mcp-go library patterns.

## Before/After

**Before:**
```go
tool := mcp.NewTool("listTables", 
    mcp.WithDescription("Lists all the tables..."))
```

**After:**
```go
tool := mcp.NewTool("listTables",
    mcp.WithDescription("Lists all the tables..."),
    mcp.WithTitleAnnotation("List Tables"),
    mcp.WithReadOnlyHintAnnotation(true),
)
```