### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Finally, it can act as a [MySQL server](https://anyquery.dev/docs/usage/mysql-se
 
 ![Anyquery header](https://anyquery.dev/images/release-header.png)
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/julien040-anyquery).
+
 ## Usage
 
 ### Connecting LLM


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/julien040-anyquery)