### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Anyquery
 
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fanyquery%2Fjulien040.svg)](https://mcptoplist.com/server/mcp.so%2Fanyquery%2Fjulien040)
+
 <img src="https://anyquery.dev/images/logo-shadow.png" alt="Anyquery logo" width="96"></img>
 
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/julien040/anyquery/total)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **Anyquery MCP Server** is currently ranked **#516**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fanyquery%2Fjulien040.svg)](https://mcptoplist.com/server/mcp.so%2Fanyquery%2Fjulien040)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Anyquery MCP Server!
