### PR TITLE
fix(postgres): avoid double-quoting column identifiers

### DIFF
--- a/module/db_helper.go
+++ b/module/db_helper.go
@@ -8,7 +8,7 @@ import (
 )
 
 type databaseColumn struct {
-	// The name of the column in the database
+	// The raw name of the column in the database, without identifier quoting
 	Realname string
 	// The name of the column locally
 	SQLiteName string
@@ -82,20 +82,21 @@ func constructSQLQuery(
 		if !colInfo.Supported {
 			continue
 		}
+		quotedColumn := flavor.Quote(colInfo.Realname)
 
 		switch c.Op {
 		case sqlite3.OpEQ:
-			andConditions = append(andConditions, query.Equal(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.Equal(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpGT:
-			andConditions = append(andConditions, query.GreaterThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.GreaterThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpGE:
-			andConditions = append(andConditions, query.GreaterEqualThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.GreaterEqualThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpLT:
-			andConditions = append(andConditions, query.LessThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.LessThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpLE:
-			andConditions = append(andConditions, query.LessEqualThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.LessEqualThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpLIKE:
-			andConditions = append(andConditions, query.Like(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.Like(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpGLOB:
 			// Not supported
 			continue
@@ -197,20 +198,21 @@ func efficientConstructSQLQuery(
 		if !colInfo.Supported {
 			continue
 		}
+		quotedColumn := flavor.Quote(colInfo.Realname)
 
 		switch c.Op {
 		case sqlite3.OpEQ:
-			andConditions = append(andConditions, query.Equal(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.Equal(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpGT:
-			andConditions = append(andConditions, query.GreaterThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.GreaterThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpGE:
-			andConditions = append(andConditions, query.GreaterEqualThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.GreaterEqualThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpLT:
-			andConditions = append(andConditions, query.LessThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.LessThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpLE:
-			andConditions = append(andConditions, query.LessEqualThan(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.LessEqualThan(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpLIKE:
-			andConditions = append(andConditions, query.Like(colInfo.Realname, colInfo.DefaultValue))
+			andConditions = append(andConditions, query.Like(quotedColumn, colInfo.DefaultValue))
 		case sqlite3.OpGLOB:
 			// Not supported
 			continue

--- a/module/db_helper_test.go
+++ b/module/db_helper_test.go
@@ -1,0 +1,50 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/huandu/go-sqlbuilder"
+	sqlite3 "github.com/julien040/go-sqlite3-anyquery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresQueryQuotesRawColumnNamesOnce(t *testing.T) {
+	columns := []databaseColumn{
+		{
+			Realname:  "version",
+			Supported: true,
+		},
+	}
+
+	query, _, _, _ := constructSQLQuery(
+		[]sqlite3.InfoConstraint{{Column: 0, Op: sqlite3.OpEQ, Usable: true}},
+		[]sqlite3.InfoOrderBy{{Column: 0}},
+		columns,
+		`"public"."schema_migrations"`,
+		sqlbuilder.PostgreSQL,
+	)
+
+	got, _ := query.Build()
+	require.Equal(t, `SELECT "version" FROM "public"."schema_migrations" WHERE "version" = $1 ORDER BY "version" ASC`, got)
+}
+
+func TestEfficientPostgresQueryQuotesRawColumnNamesOnce(t *testing.T) {
+	columns := []databaseColumn{
+		{
+			Realname:  "dirty",
+			Supported: true,
+		},
+	}
+
+	query, _, _, _ := efficientConstructSQLQuery(
+		nil,
+		nil,
+		columns,
+		`"public"."schema_migrations"`,
+		1,
+		sqlbuilder.PostgreSQL,
+	)
+
+	got, _ := query.Build()
+	require.Equal(t, `SELECT "dirty" FROM "public"."schema_migrations"`, got)
+}

--- a/module/postgres.go
+++ b/module/postgres.go
@@ -252,7 +252,7 @@ func (m *PostgresModule) Connect(c *sqlite3.SQLiteConn, args []string) (sqlite3.
 
 		schema.WriteString(fmt.Sprintf("  %s %s", localColumnName, columnType))
 		internalSchema = append(internalSchema, databaseColumn{
-			Realname:     fmt.Sprintf(`"%s"`, columnName),
+			Realname:     columnName,
 			SQLiteName:   localColumnName,
 			Type:         columnType,
 			Supported:    typeSupported,
@@ -532,7 +532,7 @@ func (t *PostgresTable) Insert(id any, vals []any) (int64, error) {
 		if v == nil {
 			continue
 		}
-		cols = append(cols, t.schema[i].Realname)
+		cols = append(cols, sqlbuilder.PostgreSQL.Quote(t.schema[i].Realname))
 		values = append(values, v)
 	}
 	builder.Cols(cols...)
@@ -562,7 +562,7 @@ func (t *PostgresTable) Update(id any, vals []any) error {
 		if v == nil {
 			continue
 		}
-		sets = append(sets, builder.Assign(t.schema[i].Realname, v))
+		sets = append(sets, builder.Assign(sqlbuilder.PostgreSQL.Quote(t.schema[i].Realname), v))
 	}
 
 	builder.Set(sets...)


### PR DESCRIPTION
## Summary

- Fix PostgreSQL virtual-table queries that double-quote already-quoted column names.
- Keep database column metadata raw and apply PostgreSQL identifier quoting at each SQL construction boundary.
- Quote SELECT, WHERE, ORDER BY, INSERT, and UPDATE column references consistently.
- Add regression coverage for both regular and efficient query construction paths.

Fixes #82

## Validation

Passed in a Go 1.26 Linux container with the repository build tags:

- Module regression and relevant test suite: 25 tests passed (excluding `TestJsonModule`, which depends on an external sample URL currently returning HTTP 404).
- `go vet -tags vtable,fts5,sqlite_json,sqlite_math_functions ./module`
- `gofmt -d module/postgres.go module/db_helper.go module/db_helper_test.go`
- `git diff --check`

I also ran the full repository command:

```text
go test -tags vtable,fts5,sqlite_json,sqlite_math_functions ./...
```

It remains blocked by unrelated baseline failures: the external JSON fixture returns 404, namespace MySQL tests have existing argument-count assertion failures, sqlparser tests have existing parser/format expectation failures, and the `test` package contains multiple standalone `main` programs that cannot compile together.